### PR TITLE
브루트 포스] 외판원 순회2 - 백준 10971번

### DIFF
--- a/브루트포스/외판원-순회2/traveling_salesman_problem_test.py
+++ b/브루트포스/외판원-순회2/traveling_salesman_problem_test.py
@@ -13,32 +13,24 @@ def next_permutation(nums):
     return nums
 
 
-def get_permutations(nums):
-    permutations = []
-    while nums != -1:
-        permutations.append(nums[:])
-        nums = next_permutation(nums)
-    return permutations
-
-
 if __name__ == "__main__":
     min = 1000001
     n = int(input())
     nums = [num for num in range(n)]
     board = [list(map(int, input().split())) for _ in range(n)]
 
-    routes = get_permutations(nums)
-    for route in routes:
-        total = 0
-        for i in range(len(route)):
-            start = route[i]
-            if i == len(route) - 1:
-                end = route[0]
+    while nums != -1:
+        sum = 0
+        ok = True
+        for i in range(len(nums) - 1):
+            if not board[nums[i]][nums[i + 1]]:
+                ok = False
             else:
-                end = route[i + 1]
-            total += board[start][end]
-        if total < min:
-            min = total
-        print(route, total)
+                sum += board[nums[i]][nums[i + 1]]
+        if ok and board[nums[len(nums) - 1]][nums[0]] != 0:
+            sum += board[nums[len(nums) - 1]][nums[0]]
+            if min > sum:
+                min = sum
+        nums = next_permutation(nums)
 
     print(min)

--- a/브루트포스/외판원-순회2/traveling_salesman_problem_test.py
+++ b/브루트포스/외판원-순회2/traveling_salesman_problem_test.py
@@ -20,6 +20,8 @@ if __name__ == "__main__":
     board = [list(map(int, input().split())) for _ in range(n)]
 
     while nums != -1:
+        if nums[0] != 0:
+            break
         sum = 0
         ok = True
         for i in range(len(nums) - 1):

--- a/브루트포스/외판원-순회2/traveling_salesman_problem_test.py
+++ b/브루트포스/외판원-순회2/traveling_salesman_problem_test.py
@@ -14,7 +14,7 @@ def next_permutation(nums):
 
 
 if __name__ == "__main__":
-    min = 1000001
+    min = float('inf')
     n = int(input())
     nums = [num for num in range(n)]
     board = [list(map(int, input().split())) for _ in range(n)]
@@ -25,7 +25,7 @@ if __name__ == "__main__":
         sum = 0
         ok = True
         for i in range(len(nums) - 1):
-            if not board[nums[i]][nums[i + 1]]:
+            if board[nums[i]][nums[i + 1]] == 0:
                 ok = False
             else:
                 sum += board[nums[i]][nums[i + 1]]

--- a/브루트포스/외판원-순회2/traveling_salesman_problem_test.py
+++ b/브루트포스/외판원-순회2/traveling_salesman_problem_test.py
@@ -1,0 +1,44 @@
+def next_permutation(nums):
+    for i in reversed(range(len(nums) - 1)):
+        if nums[i + 1] > nums[i]:
+            break
+    else:
+        return -1
+
+    j = next(j for j in reversed(range(i + 1, len(nums))) if nums[i] < nums[j])
+
+    nums[i], nums[j] = nums[j], nums[i]
+
+    nums[i + 1:] = reversed(nums[i + 1:])
+    return nums
+
+
+def get_permutations(nums):
+    permutations = []
+    while nums != -1:
+        permutations.append(nums[:])
+        nums = next_permutation(nums)
+    return permutations
+
+
+if __name__ == "__main__":
+    min = 1000001
+    n = int(input())
+    nums = [num for num in range(n)]
+    board = [list(map(int, input().split())) for _ in range(n)]
+
+    routes = get_permutations(nums)
+    for route in routes:
+        total = 0
+        for i in range(len(route)):
+            start = route[i]
+            if i == len(route) - 1:
+                end = route[0]
+            else:
+                end = route[i + 1]
+            total += board[start][end]
+        if total < min:
+            min = total
+        print(route, total)
+
+    print(min)


### PR DESCRIPTION
# 외판원 순회2

외판원이 도시를 방문하면서 드는 비용이 가장 적은 비용을 찾는 문제. 

## 순열
`1부터 N` 까지 번호가 매겨진 도시가 존재하고, 한 도시에서 출발하여 모두 거쳐 다시 원래의 도시로 돌아와야 한다. 이러한 여행 계획을 세울 때 각 도시를 방문하여 드는 비용은 행렬 `W[i][j]` 형태로 주어진다고 한다.

외판원의 여행 경로는 어떻게 구할 수 있을까? 바로 순열을 이용하는 것이다. 
1부터 N까지의 숫자에 대해서 순열을 구하면 1부터 N까지의 도시를 방문하는 모든 경우의 수를 구할 수 있다. 이제 이 경우의 수에 대해서 가중치를 계산하여 최소 비용을 출력하면 된다.

- 이 때 가는 길이 존재하지 않은 경우는 가중치의 값이 0임을 기억하자. 길이 끊겨있으면 나머지 길에 대한 계산은 할 필요가 없다.
- 각 행렬의 성분이 `1000000` 이라는 말을 보고 가중치의 총 합의 최소값을 구하기 위해 min의 값을 `1000001` 로 잡았다. 하지만 이렇게 하면 모든 가중치가 1000000 일 때 최소값을 제대로 구할 수 없다. 따라서 min의 값은 엄청 큰 값으로 잡아야 한다. 이를 해 주는것이 `float('inf')`

## 시간복잡도
- `1 부터 N` 까지의 숫자로 순열을 만드는데 드는 시간복잡도는 `n!`
- 여기에 가중치를 합하여 비용을 계산해야 하므로 `n`
- 총 `O(n * n!)`

## 시간을 단축시키기
외판원은 다시 원래의 도시로 돌아와야 한다. 즉 `1->2->3->4->1` 처럼 방문을 하게 된다. 
여기서 `1->2->3->4->1`로 방문하여 드는 비용은 `2->3->4->1->2` 과 같다는 걸 알 수 있다. 왜냐하면 다시 처음의 도시로 돌아오기 때문이다.
즉, `1->2->3->4` 를 구하면 `2->3->4->1`, `3->4->1->2`, `4->1->2->3` 은 같다는 말이다.
따라서 시간복잡도를 `n` 정도 줄일 수 있다. 
