### PR TITLE
재귀] 퇴사 - 백준 14501번

### DIFF
--- a/재귀/퇴사/baekjoon_14501_test.py
+++ b/재귀/퇴사/baekjoon_14501_test.py
@@ -1,4 +1,3 @@
-inf = -10 ** 9
 n = int(input())
 t = [0] * (n + 1)
 p = [0] * (n + 1)
@@ -17,8 +16,8 @@ def go(day, s):
     if day > n + 1:
         return
 
-    go(day + 1, s)
     go(day + t[day], s + p[day])
+    go(day + 1, s)
 
 
 go(1, 0)

--- a/재귀/퇴사/baekjoon_14501_test.py
+++ b/재귀/퇴사/baekjoon_14501_test.py
@@ -1,0 +1,25 @@
+inf = -10 ** 9
+n = int(input())
+t = [0] * (n + 1)
+p = [0] * (n + 1)
+
+for i in range(1, n + 1):
+    t[i], p[i] = map(int, input().split())
+
+ans = 0
+
+def go(day, s):
+    global ans
+    if day == n + 1:
+        ans = max(ans, s)
+        return
+
+    if day > n + 1:
+        return
+
+    go(day + 1, s)
+    go(day + t[day], s + p[day])
+
+
+go(1, 0)
+print(ans)


### PR DESCRIPTION
# 퇴사
기존의 재귀 문제들과 다른점이 있다면 이동하는 `index`의 범위가 다르다. 기존의 재귀 문제들은 index를 하나씩 증가시키는 반면 이 문제는 상담 기간동안의 날짜를 건너뛰어야 하기 때문에 `index + t[day]` 와 같이 건너뛰도록 설계되었다.

## 알아둬야 할 python skill
- 초기에 `0`으로 채워져 있는 n 길이의 리스트를 만드려면 아래와 같이 한다.
```python
some_list = [0] * (n)
```
- 전역 변수를 선언하고 어떤 스코프 안에서 해당 전역 변수를 사용하려면 `global` 키워드를 붙여 사용해야 한다.
