### PR TITLE
그래프] 연결 요소 - 백준 11724번

### DIFF
--- a/그래프/연결요소/baekjoon-11724_test.py
+++ b/그래프/연결요소/baekjoon-11724_test.py
@@ -1,0 +1,30 @@
+import sys
+sys.setrecursionlimit(100000)
+
+def dfs(vertex, visited, adjacency_list):
+    visited[vertex] = True
+    for next_vertex in adjacency_list[vertex]:
+        if not visited[next_vertex]:
+            dfs(next_vertex, visited, adjacency_list)
+
+
+def solution(n, adjacency_list):
+    visited = [False] * (n + 1)
+    answer = 0
+    for start in range(1, n + 1):
+        if not visited[start]:
+            dfs(start, visited, adjacency_list)
+            answer += 1
+
+    return answer
+
+
+if __name__ == "__main__":
+    n, m = map(int, sys.stdin.readline().split())
+    adjacency_list = [[] for _ in range(n + 1)]
+    for _ in range(m):
+        u, v = map(int, sys.stdin.readline().split())
+        adjacency_list[u].append(v)
+        adjacency_list[v].append(u)
+
+    print(solution(n, adjacency_list))


### PR DESCRIPTION
# 연결 요소
간단한 BFS, DFS 문제. 하지만 파이썬으로 문제를 풀면서 주의해야 할 이슈를 알게 되었다.
재귀를 사용하는 코드가 포함된 풀이에서 다른 코드에 이상이 없는데도 런타임 에러가 나타나서 왜 그런지 찾아보았다.

이에 대한 해결책은 파이썬 코딩 도장 Q & A에서 알 수 있었다. #29 
파이썬은 재귀호출을 최대 몇 번까지 할 수 있나요?

> 파이썬 인터프리터 소스 코드(C 언어)에는 최대 재귀 깊이가 1,000으로 정의되어 있으며 최대 재귀 깊이는 sys 모듈의 getrecursionlimit 함수로 확인할 수 있습니다.
```python
import sys
sys.getrecursionlimit()
# 1000
```
> 만약 최대 재귀 깊이를 늘리려면 sys 모듈의 setrecursionlimit 함수를 사용하면 됩니다.
```python
sys.setrecursionlimit(2000)    # 최대 재귀호출 횟수를 2000으로 늘림
```
그래서 이 문제에서도 최대 재귀 깊이를 `100000`으로 늘려줬더니 해결되었다.