### PR TITLE
그래프(BFS, 덱)] 알고스팟 - 백준 1261 번

### DIFF
--- a/그래프/알고스팟/baekjoon-1261.py
+++ b/그래프/알고스팟/baekjoon-1261.py
@@ -1,0 +1,38 @@
+import sys
+from collections import deque
+
+dy = [-1, +1, 0, 0]
+dx = [0, 0, -1, +1]
+
+
+def bfs(m, n, miro):
+    q = deque()
+    dist = [[-1] * m for _ in range(n)]
+    q.append((0, 0))
+    dist[0][0] = 0
+
+    while q:
+        y, x = q.popleft()
+        for i in range(4):
+            ny, nx = y + dy[i], x + dx[i]
+            if 0 <= ny < n and 0 <= nx < m:
+                if miro[ny][nx] == 0 and dist[ny][nx] == -1:
+                    q.appendleft((ny, nx))
+                    dist[ny][nx] = dist[y][x]
+                if miro[ny][nx] == 1 and dist[ny][nx] == -1:
+                    q.append((ny, nx))
+                    dist[ny][nx] = dist[y][x] + 1
+
+    return dist[n - 1][m - 1]
+
+
+def solution(m, n, miro):
+    return bfs(m, n, miro)
+
+
+if __name__ == "__main__":
+    m, n = map(int, sys.stdin.readline().split())
+    miro = [list(map(int, sys.stdin.readline().strip())) for _ in range(n)]
+    answer = solution(m, n, miro)
+
+    print(answer)


### PR DESCRIPTION
# 알고스팟
- 이 문제에서 비용은 몇 개의 벽을 부수는가를 나타낸다.
- 따라서 가중치는 벽을 부수는 횟수이다.
- 부수지 않고 이동해도 될 때는 가중치가 0이므로 두 개의 가중치가 존재한다. `1과 0`
- 만약 부수지 않아도 된다면 덱의 앞 부분에 추가하여 우선적으로 뺄 수 있도록 한다. 벽을 최소한으로 부숴 도착지에 다다르는 것이 목적이므로 우선되어야 한다.
- 만약 벽을 부수는 행위가 덱의 앞 부분에 추가된다면 벽을 부수지 않고도 이동할 수 있는 정점임에도 불구하고 부숴서 가게 되므로 최소 비용에 적절하지 않다.
