### PR TITLE
그래프(BFS)] 섬의 개수 - 백준 4963 번

### DIFF
--- a/그래프/섬의개수/baekjoon-4963.py
+++ b/그래프/섬의개수/baekjoon-4963.py
@@ -1,0 +1,35 @@
+from collections import deque
+
+dy = [-1, 1, 0, 0, -1, 1, -1, 1]
+dx = [0, 0, -1, 1, -1, -1, 1, 1]
+
+
+def bfs(y, x, w, h, check, field, number):
+    q = deque()
+    q.append((y, x))
+    check[y][x] = number
+
+    while q:
+        y, x = q.popleft()
+        for i in range(8):
+            ny, nx = y + dy[i], x + dx[i]
+            if 0 <= ny < h and 0 <= nx < w:
+                if field[ny][nx] == 1 and check[ny][nx] == -1:
+                    q.append((ny, nx))
+                    check[ny][nx] = number
+
+
+if __name__ == "__main__":
+    while True:
+        w, h = map(int, input().split())
+        check = [[-1] * w for _ in range(h)]
+        field = [list(map(int, input().split())) for _ in range(h)]
+        number = 0
+        for i in range(h):
+            for j in range(w):
+                if field[i][j] == 1 and check[i][j] == -1:
+                    number += 1
+                    bfs(i, j, w, h, check, field, number)
+        if w == 0 and h == 0:
+            break
+        print(number)


### PR DESCRIPTION
- 1은 땅이고 0은 바다이다.
- 상,하,좌,우,대각선 방향에 땅이 연결되어 있으면 하나의 섬으로 본다.
- 섬의 개수를 카운트 하여 정답을 출력한다.
- 주어진 지도를 중첩 for문으로 돌면서 1이 나오면 해당 좌표부터 bfs를
  돌려 주변의 1에 같은 번호를 부여한다.
- bfs를 한번 돌 때 마다 부여할 번호를 추가한다. 따라서 이 번호를
  정답으로 출력하면 된다.