### PR TITLE
다이나믹 프로그래밍] 쉬운 계단 수 - 백준 10884 번

### DIFF
--- a/다이나믹프로그래밍/쉬운계단수/baekjoon-10844.py
+++ b/다이나믹프로그래밍/쉬운계단수/baekjoon-10844.py
@@ -1,0 +1,19 @@
+n = int(input())
+mod = 10 ** 9
+
+dp = [[0] * 10 for _ in range(n + 1)]
+
+for i in range(1, n + 1):
+    for j in range(10):
+        if i == 1 and j != 0:
+            dp[i][j] = 1
+        else:
+            if j - 1 >= 0 and j + 1 <= 9:
+                dp[i][j] = dp[i - 1][j - 1] + dp[i - 1][j + 1]
+            if j + 1 == 10:
+                dp[i][j] = dp[i - 1][j - 1]
+            if j - 1 == -1:
+                dp[i][j] = dp[i - 1][j + 1]
+        dp[i][j] %= mod
+
+print(sum(dp[n]) % mod)


### PR DESCRIPTION
# 쉬운 계단 수
- 계단 수는 앞, 뒤의 차이가 1인 수를 의미한다. 예를 들어, 45654 는 계단 수 이지만 2456은 계단수가 아니다.
- `dp[i][j]`는 길이가 i이고 끝자리 숫자가 j인 경우의 계단 수의 개수를 담는다.
- `dp[1][1 ~ 9]` 는 모두 1이다. 한 자리 숫자는 모두 계단 수 이고 첫 시작이 0일 때만 0이다.
- 다시 예를 들어보면 끝 숫자가 3이고 길이가 2인 경우 계단 수는 23, 43 이 될 것이다. 
- 이를 점화식으로 풀어 쓰면 `dp[i][j] = dp[i-1][j-1] + dp[i-1][j+1]` 라 할 수 있겠다.
- `dp[i-1][j-1]` 은 끝 자리가 j일 경우 이전 자리는 j-1 이거나 j+1 이어야 한다. 이전 자리까지의 계단 수는 길이가 i-1 이고 이는 `dp[i-1][j-1], dp[i-1][j+1]` 에 담겨 있다고 할 수 있다.