### PR TITLE
다이나믹 프로그래밍] 스티커 - 백준 9465번

### DIFF
--- a/다이나믹프로그래밍/스티커/baekjoon-9465_test.py
+++ b/다이나믹프로그래밍/스티커/baekjoon-9465_test.py
@@ -1,0 +1,47 @@
+def test_solution():
+    assert solution(5, [
+        [50, 10, 100, 20, 40],
+        [30, 50, 70, 10, 60],
+    ]) == 260
+
+    assert solution(7, [
+        [10, 30, 10, 50, 100, 20, 40],
+        [20, 40, 30, 50, 60, 20, 80],
+    ]) == 290
+
+    assert solution(1, [
+        [10],
+        [20],
+    ]) == 20
+
+    assert solution(2, [
+        [10, 100],
+        [20, 50],
+    ]) == 120
+
+
+def solution(n, stickies):
+    if n == 1:
+        return max(stickies[0][0], stickies[1][0])
+
+    dp = [[0] * n for _ in range(2)]
+
+    dp[0][0] = stickies[0][0]
+    dp[1][0] = stickies[1][0]
+
+    dp[0][1] = dp[1][0] + stickies[0][1]
+    dp[1][1] = dp[0][0] + stickies[1][1]
+
+    for i in range(2, n):
+        dp[0][i] = max(dp[1][i-1], dp[1][i-2]) + stickies[0][i]
+        dp[1][i] = max(dp[0][i-1], dp[0][i-2]) + stickies[1][i]
+
+    return max(dp[0][n - 1], dp[1][n - 1])
+
+
+t = int(input())
+for _ in range(t):
+    n = int(input())
+    stickies = [list(map(int, input().split())) for _ in range(2)]
+
+    print(solution(n, stickies))

--- a/다이나믹프로그래밍/스티커/baekjoon-9465_test.py
+++ b/다이나믹프로그래밍/스티커/baekjoon-9465_test.py
@@ -33,10 +33,46 @@ def solution(n, stickies):
     dp[1][1] = dp[0][0] + stickies[1][1]
 
     for i in range(2, n):
-        dp[0][i] = max(dp[1][i-1], dp[1][i-2]) + stickies[0][i]
-        dp[1][i] = max(dp[0][i-1], dp[0][i-2]) + stickies[1][i]
+        dp[0][i] = max(dp[1][i - 1], dp[1][i - 2]) + stickies[0][i]
+        dp[1][i] = max(dp[0][i - 1], dp[0][i - 2]) + stickies[1][i]
 
     return max(dp[0][n - 1], dp[1][n - 1])
+
+
+def test_solution2():
+    assert solution2(5, [
+        [50, 10, 100, 20, 40],
+        [30, 50, 70, 10, 60],
+    ]) == 260
+
+    assert solution2(7, [
+        [10, 30, 10, 50, 100, 20, 40],
+        [20, 40, 30, 50, 60, 20, 80],
+    ]) == 290
+
+    assert solution2(1, [
+        [10],
+        [20],
+    ]) == 20
+
+    assert solution2(2, [
+        [10, 100],
+        [20, 50],
+    ]) == 120
+
+
+def solution2(n, stickies):
+    dp = [[0] * 3 for _ in range(n)]
+
+    dp[0][1] = stickies[0][0]
+    dp[0][2] = stickies[1][0]
+
+    for i in range(1, n):
+        dp[i][0] = max(dp[i - 1][0], dp[i - 1][1], dp[i - 1][2])
+        dp[i][1] = max(dp[i - 1][0], dp[i - 1][2]) + stickies[0][i]
+        dp[i][2] = max(dp[i - 1][0], dp[i - 1][1]) + stickies[1][i]
+
+    return max(dp[n - 1])
 
 
 t = int(input())


### PR DESCRIPTION
# 스티커

문제 링크 : [스티커](https://www.acmicpc.net/problem/9465)

## 문제 풀이
<img width="523" alt="handwriting" src="https://user-images.githubusercontent.com/45390172/93041834-7c52ae80-f688-11ea-9ecb-0edaa35e16e8.PNG">

## 점화식
```
dp[0][j] = max(dp[1][j - 1], dp[1][j - 2]) + m[0][j]
dp[1][j] = max(dp[0][j - 1], dp[0][j - 2]) + m[1][j]
```

## 다른 점화식 풀이
위 풀이는 j번째 열에서 선택한 숫자를 포함하여 만들어지는 최대 합을 각각의 행에 따라 나누어 저장하였다. 
즉, `dp[0][j]` 는 j열의 위에 있는 숫자를 선택했을 때 올 수 있는 최대 합은 바로 전 열에서 아래 숫자를 선택했을 경우 (`dp[1][j - 1]`)나 바로 전을 선택하지 않고 전전 열을 선택했을 경우(`dp[1][j - 2]`) 둘 중 최대값과 현재 선택한 숫자를 더해 j열까지의 최대 합을 구했었다.

이렇게 복잡하게 하지 않고, dp를 3가지 상태로 나눈다.
- j번째 열을 선택하지 않음
- j번째 열에서 위에 있는 숫자를 선택함
- j번째 열에서 아래에 있는 숫자를 선택함

이에 따라 점화식은 다음과 같다.
```python
dp[i][j] = 2 * i 에서 얻을 수 있는 최대 정수, i번 열에서 뜯는 스티커는 j

# i번째 열이 선택되지 않았다면 최대값은 이전 열에서 선택되지 않았거나, 위에를 선택했거나, 아래를 선택해 얻은 최대값 중 하나이다.
dp[i][0] = max(dp[i - 1][0], dp[i - 1][1], dp[i - 1][2])
# i번째 열에서 위에 숫자를 선택했다면, 이전 열에서 선택하지 않았거나, 이전 열에서 아래 숫자를 선택했을 때 얻은 최대값을 현재 선택한
# 숫자와 더한 결과이다.
dp[i][1] = max(dp[i - 1][0], dp[i - 1][2]) + stickies[0][i]
# i번째 열에서 아래 숫자를 선택했다면, 이전 열에서 선택하지 않았거나, 이전 열에서 위에 숫자를 선택했을 때 얻은 최대값을 현재 선택한
# 숫자와 더한 결과이다.
dp[i][2] = max(dp[i - 1][0], dp[i - 1][1]) + stickies[1][i]
```