### PR TITLE
다이나믹 프로그래밍] 연속합 - 백준 1912번

### DIFF
--- a/다이나믹프로그래밍/연속합/baekjoon-1912_test.py
+++ b/다이나믹프로그래밍/연속합/baekjoon-1912_test.py
@@ -1,0 +1,20 @@
+def test_solution():
+    assert solution(
+        10,
+        [10, -4, 3, 1, 5, 6, -35, 12, 21, -1],
+    ) == 33
+
+
+def solution(n, nums):
+    dp = [0] * n
+
+    dp[0] = nums[0]
+    for i in range(1, len(nums)):
+        dp[i] = max(nums[i], nums[i] + dp[i - 1])
+
+    return max(dp)
+
+
+n = int(input())
+nums = list(map(int, input().split()))
+print(solution(n, nums))


### PR DESCRIPTION
# 연속 합
문제 링크 : [연속 합](https://www.acmicpc.net/problem/1912)

## 문제 풀이
n개의 수열이 주어질 때 연속한 부분 합이 최대가 되는 값을 구하는 문제.

n 제한이 크기 때문에 단순 중첩 반복문을 이용해서는 풀 수 없다.

### 점화식
```
dp[i] = i 번째 수가 포함되는 가장 큰 연속 합
```
숫자는 연속되어야 하므로 i 번째 수가 가장 큰 연속 합이 되려면 `dp[i] = nums[i] + dp[i - 1]`이어야 한다. `dp[i - 1]` 에는 i - 1 번째 수가 포함되는 가장 큰 연속합이 들어 있으므로 현재 수와 합치면 연속 합 조건이 성립된다.

또한 연속합을 유지할 필요 없이 새로운 연속 합을 시작하는 경우도 있다. 따라서 dp[i] 에는 다음과 같은 식이 들어간다.
```
dp[i] = max(num[i], num[i] + dp[i - 1])
```
