### PR TITLE
다이나믹 프로그래밍] - 백준 13398 번

### DIFF
--- a/다이나믹프로그래밍/연속합2/baekjoon-13398_test.py
+++ b/다이나믹프로그래밍/연속합2/baekjoon-13398_test.py
@@ -1,0 +1,30 @@
+def test_solution():
+    assert solution(
+        10,
+        [10, -4, 3, 1, 5, 6, -35, 12, 21, -1],
+    ) == 54
+
+
+def get_dp(n, nums):
+    dp = [0] * n
+    dp[0] = nums[0]
+
+    for i in range(1, n):
+        dp[i] = max(nums[i], nums[i] + dp[i - 1])
+    return dp
+
+
+def solution(n, nums):
+    dp_l = get_dp(n, nums)
+    dp_r = get_dp(n, nums[::-1])[::-1]
+
+    ans = max(dp_l)
+    for i in range(1, n-1):
+        if ans < dp_l[i - 1] + dp_r[i + 1]:
+            ans = dp_l[i - 1] + dp_r[i + 1]
+
+    return ans
+
+n = int(input())
+nums = list(map(int, input().split()))
+print(solution(n, nums))


### PR DESCRIPTION
# 연속합2
문제 링크 : [연속합2](https://www.acmicpc.net/problem/13398)

## 문제 풀이
#63 문제와 방법은 똑같다. 수열의 왼쪽에서 오른쪽 끝까지 순회하며 연속합을 구했다면, 이번에는 오른쪽 끝에서부터 왼쪽 끝까지 순회하며 구한 연속합을 구한다.

주어진 수열의 숫자 하나를 제거 할 수 있다고 하였으므로, k 번째 숫자를 제외한 양쪽의 최대 합을 더한 값 중에서 최대값을 구하면 된다.

숫자를 제거하지 않아도 되므로 초기 ans의 값은 `max(dl)` 이다.
```
ans = max(dr[k + 1] + dl[k - 1])
```
