### PR TITLE
백트래킹] 부등호 - 백준 2529 번

### DIFF
--- a/백트래킹/부등호/baekjoon-2529.cpp
+++ b/백트래킹/부등호/baekjoon-2529.cpp
@@ -1,0 +1,14 @@
+#include<cstdio>
+#include<cstring>
+#include<vector>
+#include<tuple>
+#include<deque>
+#include<queue>
+#include<algorithm>
+
+using namespace std;
+
+int main() {
+  
+  return 0;
+}

--- a/백트래킹/부등호/baekjoon-2529.cpp
+++ b/백트래킹/부등호/baekjoon-2529.cpp
@@ -1,10 +1,10 @@
-#include<iostream>
-#include<vector>
-#include<string>
-#include<tuple>
-#include<deque>
-#include<queue>
-#include<algorithm>
+#include <iostream>
+#include <vector>
+#include <string>
+#include <tuple>
+#include <deque>
+#include <queue>
+#include <algorithm>
 
 using namespace std;
 
@@ -13,41 +13,57 @@ bool check[10];
 char oper[10];
 vector<string> ans;
 
-bool ok(string num) {
-  for(int i=0; i<k; i++) {
-    if(oper[i] == '<' && (int)num[i] > (int)num[i + 1]) return false;
-    if(oper[i] == '>' && (int)num[i] < (int)num[i + 1]) return false;
+bool good(char current_number, char next_number, char op)
+{
+  if (op == '<')
+  {
+    if (current_number > next_number)
+      return false;
+  }
+  if (op == '>')
+  {
+    if (current_number < next_number)
+      return false;
   }
   return true;
 }
 
-void go(int index, string num) {
-  if(index == k + 1) {
-    if(ok(num)) {
-      ans.push_back(num);
-    }
+void go(int index, string num)
+{
+  if (index == k + 1)
+  {
+    ans.push_back(num);
     return;
   }
-  for(int i=0; i<=9; i++) {
-    if(check[i]) continue;
-    check[i] = true;
-    go(index + 1, num+to_string(i));
-    check[i] = false;
+  for (int i = 0; i <= 9; i++)
+  {
+    if (check[i])
+      continue;
+    if (index == 0 || good(num[index - 1], i + '0', oper[index - 1]))
+    {
+      check[i] = true;
+      go(index + 1, num + to_string(i));
+      check[i] = false;
+    }
   }
 }
-int main() {
+
+int main()
+{
   ios::sync_with_stdio(false);
   cin.tie(NULL);
   cout.tie(NULL);
-  
+
   cin >> k;
   string num;
-  for(int i = 0; i < k; i++) {
-    cin >> oper[i];  
+  for (int i = 0; i < k; i++)
+  {
+    cin >> oper[i];
   }
 
   go(0, num);
-  cout << ans[0] << endl;
+
   cout << ans[ans.size() - 1] << endl;
+  cout << ans[0] << endl;
   return 0;
 }

--- a/백트래킹/부등호/baekjoon-2529.cpp
+++ b/백트래킹/부등호/baekjoon-2529.cpp
@@ -1,6 +1,6 @@
-#include<cstdio>
-#include<cstring>
+#include<iostream>
 #include<vector>
+#include<string>
 #include<tuple>
 #include<deque>
 #include<queue>
@@ -8,7 +8,46 @@
 
 using namespace std;
 
+int k;
+bool check[10];
+char oper[10];
+vector<string> ans;
+
+bool ok(string num) {
+  for(int i=0; i<k; i++) {
+    if(oper[i] == '<' && (int)num[i] > (int)num[i + 1]) return false;
+    if(oper[i] == '>' && (int)num[i] < (int)num[i + 1]) return false;
+  }
+  return true;
+}
+
+void go(int index, string num) {
+  if(index == k + 1) {
+    if(ok(num)) {
+      ans.push_back(num);
+    }
+    return;
+  }
+  for(int i=0; i<=9; i++) {
+    if(check[i]) continue;
+    check[i] = true;
+    go(index + 1, num+to_string(i));
+    check[i] = false;
+  }
+}
 int main() {
+  ios::sync_with_stdio(false);
+  cin.tie(NULL);
+  cout.tie(NULL);
   
+  cin >> k;
+  string num;
+  for(int i = 0; i < k; i++) {
+    cin >> oper[i];  
+  }
+
+  go(0, num);
+  cout << ans[0] << endl;
+  cout << ans[ans.size() - 1] << endl;
   return 0;
 }

--- a/백트래킹/부등호/baekjoon_2529.py
+++ b/백트래킹/부등호/baekjoon_2529.py
@@ -1,0 +1,31 @@
+def good(prev, curt, op):
+    if op == '<' and prev > curt:
+        return False
+    if op == '>' and prev < curt:
+        return False
+    return True
+
+
+def go(index, num):
+    if index == k + 1:
+        ans.append(num)
+        return
+
+    for i in range(10):
+        if check[i]:
+            continue
+        if index == 0 or good(int(num[index - 1]), i, operators[index - 1]):
+            check[i] = True
+            go(index + 1, num + str(i))
+            check[i] = False
+
+
+k = int(input())
+operators = input().split()
+check = [False] * 10
+ans = []
+
+go(0, '')
+
+print(ans[len(ans) - 1])
+print(ans[0])


### PR DESCRIPTION
# 부등호
기존의 브루트포스를 이용한 부등호 문제 풀이는 `k + 1`개의 숫자에 대해서 모든 순열에 대해 부등호의 배치가 가능한지 판단했었다.

하지만 이렇게 하면 정답의 가능성이 없는 순열도 검사하기 때문에 시간이 오래걸린다.

따라서 백트래킹을 적용하여, 순열을 구성하면서 해당 순열이 부등호 관계를 올바르게 구성할 수 있는지 판단하고, 그렇지 않다면 이전 재귀로 다시 돌아가는 기법을 사용하면, 부등호 관계가 일치하는 순열에 대해서만 값을 구할 수 있다.