### PR TITLE
백트래킹] 스도쿠 - 백준 2580 번

### DIFF
--- a/백트래킹/스도쿠/baekjoon-2580.cpp
+++ b/백트래킹/스도쿠/baekjoon-2580.cpp
@@ -1,0 +1,61 @@
+#include <iostream>
+#include <vector>
+#include <utility>
+
+using namespace std;
+
+int a[10][10];
+bool c[10][10];
+bool c2[10][10];
+bool c3[10][10];
+
+vector<pair<int, int>> zero_pos;
+
+int square(int row, int col) {
+  return (row / 3) * 3 + (col / 3);
+}
+
+void go(int index) {
+  if(index == zero_pos.size()) {
+    for(int i=0; i<9; i++) {
+      for(int j=0; j<9; j++) {
+        cout << a[i][j] << " ";
+      }
+      cout << endl;
+    }
+    cout << endl;
+    return;
+  }
+
+  int y = zero_pos[index].first;
+  int x = zero_pos[index].second;
+  for(int number=1; number <= 9; number++) {
+    if(c[y][number] == 0 && c2[x][number] == 0 && c3[square(y, x)][number] == 0) {
+      c[y][number] = c2[x][number] = c3[square(y, x)][number] = true;
+      a[y][x] = number;
+      go(index + 1);
+      c[y][number] = c2[x][number] = c3[square(y, x)][number] = false;
+      a[y][x] = 0;
+    }
+  }
+}
+
+int main()
+{
+  for(int i=0; i<9; i++) {
+    for(int j=0; j<9; j++) {
+      cin >> a[i][j];
+      if(a[i][j] != 0) {
+        c[i][a[i][j]] = true;
+        c2[j][a[i][j]] = true;
+        c3[square(i, j)][a[i][j]] = true;
+      }
+      else {
+        zero_pos.push_back(make_pair(i, j));
+      }
+    }
+  }
+
+  go(0);
+  return 0;
+}

--- a/백트래킹/스도쿠/baekjoon-2580.cpp
+++ b/백트래킹/스도쿠/baekjoon-2580.cpp
@@ -16,7 +16,7 @@ int square(int row, int col) {
 }
 
 void go(int index) {
-  if(index == zero_pos.size()) {
+  if(index == (int)zero_pos.size()) {
     for(int i=0; i<9; i++) {
       for(int j=0; j<9; j++) {
         cout << a[i][j] << " ";
@@ -24,7 +24,7 @@ void go(int index) {
       cout << endl;
     }
     cout << endl;
-    return;
+    exit(0);
   }
 
   int y = zero_pos[index].first;

--- a/백트래킹/스도쿠/baekjoon-2580.py
+++ b/백트래킹/스도쿠/baekjoon-2580.py
@@ -6,13 +6,13 @@ def go(index):
     if index == 81:
         for row in a:
             print(' '.join(map(str, row)))
-        return
+        return True
 
     y = index // n
     x = index % n
 
     if a[y][x] != 0:
-        go(index + 1)
+        return go(index + 1)
     else:
         for i in range(1, 10):
             if check_col[x][i] is False and check_row[y][i] is False and \
@@ -21,11 +21,14 @@ def go(index):
                     i] = True
                 a[y][x] = i
 
-                go(index + 1)
+                if go(index + 1):
+                    return True
 
                 check_col[x][i] = check_row[y][i] = check_square[square(y, x)][
                     i] = False
                 a[y][x] = 0
+
+    return False
 
 
 n = 9

--- a/백트래킹/스도쿠/baekjoon-2580.py
+++ b/백트래킹/스도쿠/baekjoon-2580.py
@@ -1,0 +1,45 @@
+def square(y, x):
+    return (y // 3) * 3 + (x // 3)
+
+
+def go(index):
+    if index == 81:
+        for row in a:
+            print(' '.join(map(str, row)))
+        return
+
+    y = index // n
+    x = index % n
+
+    if a[y][x] != 0:
+        go(index + 1)
+    else:
+        for i in range(1, 10):
+            if check_col[x][i] is False and check_row[y][i] is False and \
+                    check_square[square(y, x)][i] is False:
+                check_col[x][i] = check_row[y][i] = check_square[square(y, x)][
+                    i] = True
+                a[y][x] = i
+
+                go(index + 1)
+
+                check_col[x][i] = check_row[y][i] = check_square[square(y, x)][
+                    i] = False
+                a[y][x] = 0
+
+
+n = 9
+a = [list(map(int, input().split())) for _ in range(n)]
+
+check_col = [[False] * 10 for _ in range(n)]
+check_row = [[False] * 10 for _ in range(n)]
+check_square = [[False] * 10 for _ in range(n)]
+
+for row in range(n):
+    for col in range(n):
+        if a[row][col] != 0:
+            check_col[col][a[row][col]] = True
+            check_row[row][a[row][col]] = True
+            check_square[square(row, col)][a[row][col]] = True
+
+go(0)


### PR DESCRIPTION
# 스도쿠
주어진 `9*9` 크기의 스도쿠에 규칙에 따라 빈 칸을 채워 넣어 출력하는 문제

## 문제 풀이
이전에 풀었던 `N-Queen` 문제처럼 2차원 배열 내에서 검사를 어떻게 최적화 해야 할지 고민했다. 행과 열에 대해서 같은 숫자가 있는지 검사하는 부분을 반복문으로는 쉽게 할 수 있었지만, `3*3` 영역을 주어진 매개변수로 어떻게 구분할지 구하는것이 쉽지 않았다.

풀이 영상에서는 다음과 같이 구분짓는다.
```
1. bool c[i][j] 배열은 `i`번째 행에 숫자 `j`가 있으면 true 아니면 false
2. bool c2[i][j] 배열은 `i`번째 열에 숫자 `j`가 있으면 true 아니면 false
3. bool c3[i][j] 배열은 `i`번째 `3*3` 정사각형 영역에 숫자 `j`가 있으면 true 아니면 false
```
![IMG_38275BA5B309-1](https://user-images.githubusercontent.com/45390172/98664732-1899e880-238e-11eb-8fbe-da9a96623b79.jpeg)
위 그림처럼 2차원 배열을 정의하여 `row, col` 좌표값에 해당 숫자가 존재하는지 확인하는 것이다. 이로써 `O(1)`의 검사 시간을 갖도록 할 수 있다. 

## 나는 무엇을 할 수 있게 되었는가?
이 문제에서 특이한 점은 `9*9` 2차원 정사각형 배열을 `3*3` 영역으로 나누는 방법인데, 매우 흥미로웠다.
먼저 `y, x` 좌표값을 3으로 나눈다. 이로써 다음과 같은 좌표를 갖는다.
![IMG_411BE6978307-1](https://user-images.githubusercontent.com/45390172/98665669-53e8e700-238f-11eb-9dbf-7cefc417f6bc.jpeg)
여기에 배열 내부의 값을 위 그림처럼 `0,0,0... 1,1,1... 2,2,2...` 와 같이 구분지으려면 다음의 식을 적용하면 된다.
```
(y / 3) * 3 + (x / 3)
```
문제에서 주어진 예시 값에서 `(0, 0)` 부터 `(2, 2)` 까지의 영역은 `c3` 2차원 배열에서 숫자 `0` 번 영역이다. 
```
0 3 5
7 8 2
0 6 0
```
따라서 이는 `c3` 2차원 배열에서는 0번 행에 다음과 같이 나타날 것이다.
```cpp
false(1) true(2) true(3) false(4) true(5) true(6) true(7) true(8) false(9)
```
1, 4, 9가 0번 영역의 `3*3` 정사각형 영역에 존재하지 않으므로 false가 되는 것이다.
이를 통해 검사 시간을 매우 단축시킬 수 있다.